### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new server.js file for the graphite-demo project. The server is built with Express.js and serves a static activity feed on the '/feed' endpoint.
> 
> ## What changed
> A new file, server.js, was added to the graphite-demo project. This file sets up an Express.js server that listens on port 3000. It also defines a GET endpoint '/feed' that returns a JSON object representing an activity feed. The activity feed is a static array of objects, each representing a different type of activity (e.g., new photo upload, comment on a post, status update).
> 
> ## How to test
> 1. Pull down the changes from this PR
> 2. Install the necessary dependencies by running `npm install`
> 3. Start the server by running `node server.js`
> 4. Visit `http://localhost:3000/feed` in your browser. You should see a JSON response with the activity feed data.
> 
> ## Why make this change
> This change is necessary to provide a backend server for the graphite-demo project. The server will serve the activity feed data to the frontend, which will display it to the user. This is a basic setup and will be expanded upon in future PRs with more complex data and additional endpoints.
</details>